### PR TITLE
LDAP/LDIF UTF-8 friendly regexp

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -1,6 +1,6 @@
 /*
  * conn.c
- * $Id: conn.c,v 1.51 2006/08/01 00:07:53 ianmacd Exp $
+ * $Id$
  */
 
 #include "ruby.h"

--- a/entry.c
+++ b/entry.c
@@ -1,6 +1,6 @@
 /*
  * entry.c
- * $Id: entry.c,v 1.13 2005/03/15 10:15:32 ianmacd Exp $
+ * $Id$
  */
 
 #include "ruby.h"

--- a/example/cgi/search.html
+++ b/example/cgi/search.html
@@ -1,4 +1,4 @@
-<!-- $Id: search.html,v 1.1.1.1 2002/11/06 07:56:34 ttate Exp $ -->
+<!-- $Id$ -->
 <html>
 <head><title>Simple LDAP Gateway using Ruby/LDAP</title></head>
 <body>

--- a/extconf.rb
+++ b/extconf.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 #
 # extconf.rb for ldap extension
-# $Id: extconf.rb,v 1.7 2006/04/18 23:49:56 ianmacd Exp $
+# $Id$
 #
 
 require 'mkmf'

--- a/ldap.c
+++ b/ldap.c
@@ -1,7 +1,7 @@
 /* -*- C -*-
  *
  * ldap.c
- * $Id: ldap.c,v 1.14 2005/03/15 10:07:48 ianmacd Exp $
+ * $Id$
  */
 
 #include "ruby.h"

--- a/lib/ldap/control.rb
+++ b/lib/ldap/control.rb
@@ -1,7 +1,7 @@
 # Manipulation of LDAP control data.
 #
 #--
-# $Id: control.rb,v 1.2 2005/02/28 05:02:25 ianmacd Exp $
+# $Id$
 #++
 #
 # Copyright (C) 2004 Ian Macdonald <ian@caliban.org>

--- a/lib/ldap/ldif.rb
+++ b/lib/ldap/ldif.rb
@@ -1,7 +1,7 @@
 # Manipulation of LDIF data.
 #
 #--
-# $Id: ldif.rb,v 1.11 2005/03/03 01:32:07 ianmacd Exp $
+# $Id$
 #++
 #
 # Copyright (C) 2005 Ian Macdonald <ian@caliban.org>
@@ -104,7 +104,7 @@ module LDAP
     #
     def LDIF.unsafe_char?( str )
       # This could be written as a single regex, but this is faster.
-      str =~ /^[ :]/ || str =~ /[\x00-\x1f\x7f-\xff]/
+      str =~ /^[ :]/ || str =~ /[\u0080-\u00ff]/
     end
 
 

--- a/lib/ldap/schema.rb
+++ b/lib/ldap/schema.rb
@@ -1,7 +1,7 @@
 # Manipulation of LDAP schema data.
 #
 #--
-# $Id: schema.rb,v 1.9 2006/02/08 23:15:17 ianmacd Exp $
+# $Id$
 #++
 
 # The LDAP module encapsulates the various LDAP-related classes in their own

--- a/misc.c
+++ b/misc.c
@@ -1,5 +1,5 @@
 /* -*- C -*-
- * $Id: misc.c,v 1.11 2006/07/03 22:54:52 ianmacd Exp $
+ * $Id$
  */
 
 #include "ruby.h"

--- a/mod.c
+++ b/mod.c
@@ -1,6 +1,6 @@
 /*
  * mod.c
- * $Id: mod.c,v 1.14 2005/03/07 22:57:34 ianmacd Exp $
+ * $Id$
  */
 
 #include "ruby.h"

--- a/rbldap.h
+++ b/rbldap.h
@@ -1,6 +1,6 @@
 /*
  * rbldap.h
- * $Id: rbldap.h,v 1.17 2006/08/09 11:23:04 ianmacd Exp $
+ * $Id$
  */
 
 #ifndef RB_LDAP_H

--- a/saslconn.c
+++ b/saslconn.c
@@ -1,6 +1,6 @@
 /*
  * saslconn.c
- * $Id: saslconn.c,v 1.25 2006/02/13 17:20:32 ianmacd Exp $
+ * $Id$
  */
 
 #include "ruby.h"

--- a/sslconn.c
+++ b/sslconn.c
@@ -1,6 +1,6 @@
 /*
  * sslconn.c
- * $Id: sslconn.c,v 1.18 2006/04/19 22:13:26 ianmacd Exp $
+ * $Id$
  */
 
 #include "ruby.h"

--- a/test/setup.rb
+++ b/test/setup.rb
@@ -1,4 +1,4 @@
-# $Id: setup.rb,v 1.3 2005/03/13 10:10:56 ianmacd Exp $
+# $Id$
 #
 # Basic set-up for performing LDAP unit tests.
 

--- a/test/tc_conn.rb
+++ b/test/tc_conn.rb
@@ -1,4 +1,4 @@
-# $Id: tc_conn.rb,v 1.3 2005/03/15 01:43:59 ianmacd Exp $
+# $Id$
 #
 # A suite of unit tests for testing Ruby/LDAP connection functionality.
 

--- a/test/tc_ldif.rb
+++ b/test/tc_ldif.rb
@@ -1,4 +1,4 @@
-# $Id: tc_ldif.rb,v 1.5 2005/02/26 01:42:27 ianmacd Exp $
+# $Id$
 #
 # A suite of unit tests for testing Ruby/LDAP LDIF functionality. 
 

--- a/test/tc_schema.rb
+++ b/test/tc_schema.rb
@@ -1,4 +1,4 @@
-# $Id: tc_schema.rb,v 1.4 2005/03/13 10:11:41 ianmacd Exp $
+# $Id$
 #
 # A suite of unit tests for testing Ruby/LDAP schema functionality.
 

--- a/test/tc_search.rb
+++ b/test/tc_search.rb
@@ -1,4 +1,4 @@
-# $Id: tc_search.rb,v 1.4 2006/02/12 19:55:59 ianmacd Exp $
+# $Id$
 #
 # A suite of unit tests for testing Ruby/LDAP search functionality.
 

--- a/test/ts_ldap.rb
+++ b/test/ts_ldap.rb
@@ -1,4 +1,4 @@
-# $Id: ts_ldap.rb,v 1.1 2005/03/12 09:44:11 ianmacd Exp $
+# $Id$
 #
 # Test suite runner for Ruby/LDAP.
 

--- a/win/winlber.h
+++ b/win/winlber.h
@@ -1,5 +1,5 @@
 /* -*- C -*-
- * $Id: winlber.h,v 1.1.1.1 2002/11/06 07:56:34 ttate Exp $
+ * $Id$
  * Copyright (C) 2001 Takaaki Tateishi <ttate@kt.jaist.ac.jp>
  * References: MSDN Library, OpenLDAP, Cygwin
  */

--- a/win/winldap.h
+++ b/win/winldap.h
@@ -1,5 +1,5 @@
 /*
- * $Id: winldap.h,v 1.6 2006/08/08 14:36:15 ianmacd Exp $
+ * $Id$
  *
  * Copyright (C) 2001 Takaaki Tateishi <ttate@kt.jaist.ac.jp>
  * Copyright (C) 2006 Ian Macdonald <ian@caliban.org>


### PR DESCRIPTION
You can't require 'ldap/ldif' at all in ruby 2.0 due to an invalid multibyte range.

Possible alternatives: 
- Use utf characters instead for the range (patch included)
- Add a 'n' flag to the regexp to enforce US-ASCII
- Don't use a range at all and use String.ascii_only?, though that would break 1.8 compatibility.
