### PR TITLE
Prevent SyntaxError raised under Ruby 2.0.0 by line 107 regex

### DIFF
--- a/lib/ldap/ldif.rb
+++ b/lib/ldap/ldif.rb
@@ -1,3 +1,4 @@
+# encoding: US-ASCII
 # Manipulation of LDIF data.
 #
 #--


### PR DESCRIPTION
Under Ruby 2.0.0, one of the regexes on line 107 (/[\x00-\x1f\x7f-\xff]/) is raising a SyntaxError: invalid multibyte escape.

Resolve issue by explicitly setting the encoding to ASCII.
