### PR TITLE
The gem always canonicalizes the realm for GSSAPI with reverse DNS lookups

### DIFF
--- a/saslconn.c
+++ b/saslconn.c
@@ -106,7 +106,7 @@ rb_ldap_conn_sasl_bind (int argc, VALUE argv[], VALUE self)
 {
   RB_LDAP_DATA *ldapdata;
 
-  VALUE arg1, arg2, arg3, arg4, arg5, sasl_options = Qnil;
+  VALUE arg1, arg2, arg3, arg4, arg5, sasl_options, other_options = Qnil;
   int version;
   char *dn = NULL;
   char *mechanism = NULL;
@@ -145,8 +145,16 @@ rb_ldap_conn_sasl_bind (int argc, VALUE argv[], VALUE self)
       rb_raise (rb_eLDAP_Error, "already bound.");
     };
 
-  switch (rb_scan_args (argc, argv, "24", &arg1, &arg2, &arg3, &arg4, &arg5, &sasl_options))
+  switch (rb_scan_args (argc, argv, "25", &arg1, &arg2, &arg3, &arg4, &arg5, &sasl_options, &other_options))
     {
+    case 7:
+      /* Parse through the hash.  Currently there's only one option, nothing fancy needed. */
+      if (!NIL_P(rb_ldap_indifferent_hash_aref(other_options, "nocanon")))
+        {
+          /* Inspired by the ldapsearch -N option, inspired by the code in OpenLDAP (BSD style license) in clients/tools/common.c */
+          ldapdata->err = ldap_set_option( ldapdata->ldap, LDAP_OPT_X_SASL_NOCANON, LDAP_OPT_ON);
+          Check_LDAP_Result(ldapdata->err); 
+        }
     case 6:
       /* nothing. this requires credentials to be parsed first. we'll get defaults after arg-scanning */
     case 5:


### PR DESCRIPTION
Note: This patch is branched off of pull request 19.

Currently, ruby-ldap always canonicalizes the hostname for SASL binds.  If reverse DNS is not properly set up or cannot be modified, this can result in SASL attempting to make requests using an incorrect realm.   

This patch adds one additional argument to rb_ldap_conn_sasl_bind to include one final hash for general LDAP options.  Currently, including the symbol :nocanon in the hash will result in LDAP not canonicalizing the hostname.  This will cause similar behavior to adding the flag "-N" to ldapsearch.  See ldap_set_option(3) for more information.
