### PR TITLE
LDAP_OPT_NETWORK_TIMEOUT for openLDAP

### DIFF
--- a/ldap.c
+++ b/ldap.c
@@ -407,6 +407,9 @@ Init_ldap ()
 #ifdef LDAP_OPT_TIMELIMIT
   rb_ldap_define_opt (LDAP_OPT_TIMELIMIT);
 #endif
+#ifdef LDAP_OPT_NETWORK_TIMEOUT
+  rb_ldap_define_opt (LDAP_OPT_NETWORK_TIMEOUT);
+#endif
 #ifdef LDAP_OPT_THREAD_FN_PTRS
   rb_ldap_define_opt (LDAP_OPT_THREAD_FN_PTRS);
 #endif

--- a/rbldap.h
+++ b/rbldap.h
@@ -62,6 +62,7 @@ typedef struct rb_ldapmod_data
   LDAPMod *mod;
 } RB_LDAPMOD_DATA;
 
+struct timeval rb_time_interval(VALUE num);
 
 #ifndef HAVE_LDAP_MEMFREE
 # define ldap_memfree(ptr) free(ptr)


### PR DESCRIPTION
Thanks for actively maintaining this, it's been very handy.

I've been using it in a rails application and noticed that while connecting to a remote server, the application would get hung up for 30 seconds or so if the remote server was unreachable.  Even Timeout wouldn't break the pause.

On systems using openLDAP, you can set a max network timeout LDAP_OPT_NETWORK_TIMEOUT, and I've tried to add that as best I could.  If you think it'd be helpful, please review what I've got and let me know if I can answer any questions.

I have tested it with both 1.8 and 1.9, which are the two mentioned in your README.  I can test 2.0.0 if you'd like.

I had to implicitly declare rb_time_interval in rbldap.h for ruby 1.8.  I'm not exactly sure why, but if you have a more elegant solution, I can update my pull or you can just make the changes as needed.

Thanks!
