### PR TITLE
Fix build error with GCC 4.8.1

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -700,7 +700,7 @@ rb_ldap_conn_get_option (VALUE self, VALUE opt)
     }
   else
     {
-      rb_raise (rb_eLDAP_Error, ldap_err2string (ldapdata->err));
+      rb_raise (rb_eLDAP_Error, "%s", ldap_err2string (ldapdata->err));
     };
 #else
   rb_notimplement ();

--- a/rbldap.h
+++ b/rbldap.h
@@ -142,13 +142,13 @@ VALUE rb_ldap_mod_vals (VALUE);
 
 #define Check_LDAP_Result(err) { \
   if( (err) != LDAP_SUCCESS && (err) != LDAP_SIZELIMIT_EXCEEDED ){ \
-    rb_raise(rb_eLDAP_ResultError, ldap_err2string(err)); \
+    rb_raise(rb_eLDAP_ResultError, "%s", ldap_err2string(err)); \
   } \
 }
 
 #define Check_LDAP_OPT_Result(err) { \
   if( (err) != LDAP_OPT_SUCCESS ){ \
-    rb_raise(rb_eLDAP_ResultError, ldap_err2string(err)); \
+    rb_raise(rb_eLDAP_ResultError, "%s", ldap_err2string(err)); \
   } \
 }
 


### PR DESCRIPTION
This fixes "format not a string literal and no format arguments
[-Werror=format-security]" error:

```
conn.c: In function ‘rb_ldap_conn_start_tls_s’:
conn.c:221:3: error: format not a string literal and no format arguments [-Werror=format-security]
   Check_LDAP_Result (ldapdata->err);
   ^
....
conn.c:557:3: error: format not a string literal and no format arguments [-Werror=format-security]
   Check_LDAP_OPT_Result (ldapdata->err);
   ^
....
conn.c: In function ‘rb_ldap_conn_get_option’:
conn.c:703:7: error: format not a string literal and no format arguments [-Werror=format-security]
       rb_raise (rb_eLDAP_Error, ldap_err2string (ldapdata->err));
       ^
```
