### PR TITLE
Add missing ldap_raname_s() function availability check

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -1652,7 +1652,7 @@ rb_ldap_conn_modrdn_s (VALUE self, VALUE dn, VALUE newrdn, VALUE delete_p)
   return self;
 };
 
-#if defined(HAVE_LDAPCONTROL) && defined(HAVE_LDAP_ADD_EXT_S)
+#if defined(HAVE_LDAPCONTROL) && defined(HAVE_LDAP_RENAME_S)
 /*
  * call-seq:
  * conn.rename(dn, new_rdn, new_parent_dn, delete_old_rdn, sctrls, cctrls)  => self
@@ -1879,7 +1879,7 @@ Init_ldap_conn ()
   rb_ldap_conn_define_method ("add", rb_ldap_conn_add_s, 2);
   rb_ldap_conn_define_method ("modify", rb_ldap_conn_modify_s, 2);
   rb_ldap_conn_define_method ("modrdn", rb_ldap_conn_modrdn_s, 3);
-#if defined(HAVE_LDAPCONTROL) && defined(HAVE_LDAP_ADD_EXT_S)
+#if defined(HAVE_LDAPCONTROL) && defined(HAVE_LDAP_RENAME_S)
   rb_ldap_conn_define_method ("rename", rb_ldap_conn_rename_s, 6);
 #endif
   rb_ldap_conn_define_method ("delete", rb_ldap_conn_delete_s, 1);

--- a/extconf.rb
+++ b/extconf.rb
@@ -245,6 +245,7 @@ have_func("ldap_sort_entries")
 have_func("ldapssl_init")  # NS SDK
 have_func("ldap_sslinit")  # WLDAP32
 have_func("ldap_sasl_bind_s")
+have_func("ldap_rename_s")
 have_func("ldap_compare_s")
 have_func("ldap_add_ext_s")
 have_func("ldap_compare_ext_s")


### PR DESCRIPTION
If ldap_add_ext_s() is found, the current code assumes that
ldap_rename_s() is also found. But it is not correct. We should check
ldap_rename_s() function availability for ldap_rename_s().
