### PR TITLE
Fix system stack overflow in LDAPEntry(GH-31)

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -756,6 +756,7 @@ rb_ldap_conn_result2error (VALUE self, VALUE msg)
 
   GET_LDAP_DATA (self, ldapdata);
   Check_Kind (msg, rb_cLDAP_Entry);
+  Check_LDAPENTRY(msg);
   GET_LDAPENTRY_DATA (msg, edata);
 
   ldapdata->err = ldap_result2error (ldapdata->ldap, edata->msg, cdofree);
@@ -807,6 +808,7 @@ static VALUE
 rb_ldap_conn_invalidate_entry (VALUE msg)
 {
   RB_LDAPENTRY_DATA *edata;
+  Check_LDAPENTRY(msg);
   GET_LDAPENTRY_DATA (msg, edata);
   edata->ldap = NULL;
   edata->msg = NULL;

--- a/rbldap.h
+++ b/rbldap.h
@@ -55,6 +55,8 @@ typedef struct rb_ldapentry_data
 {
   LDAP *ldap;
   LDAPMessage *msg;
+  VALUE dn;
+  VALUE attr;
 } RB_LDAPENTRY_DATA;
 
 typedef struct rb_ldapmod_data
@@ -161,7 +163,7 @@ VALUE rb_ldap_mod_vals (VALUE);
 
 #define Check_LDAPENTRY(obj) {\
   RB_LDAPENTRY_DATA *ptr; \
-  Data_Get_Struct(obj, struct rb_ldapmsg_data, ptr); \
+  Data_Get_Struct(obj, struct rb_ldapentry_data, ptr); \
   if( ! ptr->msg ){ \
     VALUE value = rb_inspect(obj); \
     rb_raise(rb_eLDAP_InvalidEntryError, "%s is not a valid entry", \
@@ -171,11 +173,6 @@ VALUE rb_ldap_mod_vals (VALUE);
 
 #define GET_LDAPENTRY_DATA(obj,ptr) { \
   Data_Get_Struct(obj, struct rb_ldapentry_data, ptr); \
-  if( ! ptr->msg ){ \
-    VALUE value = rb_inspect(obj); \
-    rb_raise(rb_eLDAP_InvalidEntryError, "%s is not a valid entry", \
-	     StringValuePtr(value)); \
-  }; \
 }
 
 #define GET_LDAPMOD_DATA(obj,ptr) {\


### PR DESCRIPTION
* use ruby object to keep LDAP search result instead of libldap's data structure.
* use macro Check_LDAPENTRY for assertion inside native extension codes.
* remove assertion code from macro GET_LDAPENTRY_DATA. this macro may be used after libldap data structures are freed.
