### PR TITLE
quick fix for compile error on ruby-1.8.x based systems.

### DIFF
--- a/rbldap.h
+++ b/rbldap.h
@@ -55,8 +55,10 @@ typedef struct rb_ldapentry_data
 {
   LDAP *ldap;
   LDAPMessage *msg;
+#if RUBY_VERSION_CODE >= 190
   VALUE dn;
   VALUE attr;
+#endif
 } RB_LDAPENTRY_DATA;
 
 typedef struct rb_ldapmod_data
@@ -171,9 +173,20 @@ VALUE rb_ldap_mod_vals (VALUE);
   }; \
 }
 
+#if RUBY_VERSION_CODE < 190
+#define GET_LDAPENTRY_DATA(obj,ptr) { \
+  Data_Get_Struct(obj, struct rb_ldapentry_data, ptr); \
+  if( ! ptr->msg ){ \
+    VALUE value = rb_inspect(obj); \
+    rb_raise(rb_eLDAP_InvalidEntryError, "%s is not a valid entry", \
+	     StringValuePtr(value)); \
+  }; \
+}
+#else
 #define GET_LDAPENTRY_DATA(obj,ptr) { \
   Data_Get_Struct(obj, struct rb_ldapentry_data, ptr); \
 }
+#endif
 
 #define GET_LDAPMOD_DATA(obj,ptr) {\
   Data_Get_Struct(obj, struct rb_ldapmod_data, ptr); \


### PR DESCRIPTION
I just backout the fix of #32.

I confirm that the native extension code is compiled successfully using ruby-1.8.7.
But the system problem fixed by #32 IS NOT FIXED on ruby-1.8.x based systems.
