### PR TITLE
s/\t/:space:/g test/*.rb

### DIFF
--- a/test/bind-ldaps.rb
+++ b/test/bind-ldaps.rb
@@ -11,7 +11,7 @@ when /^OpenLDAP/i
   conn = LDAP::SSLConn.new($HOST, $SSLPORT, false)
 when /^Netscape/i
   conn = LDAP::SSLConn.new($HOST, $SSLPORT,
-			   false, File.expand_path("~/.netscape/cert7.db"))
+                           false, File.expand_path("~/.netscape/cert7.db"))
   conn.set_option(LDAP::LDAP_OPT_PROTOCOL_VERSION, 3)
 else
   raise(RuntimeError, "unknown vendor")

--- a/test/bind-ssl.rb
+++ b/test/bind-ssl.rb
@@ -11,7 +11,7 @@ when /^OpenLDAP/i
   conn = LDAP::SSLConn.new($HOST, $PORT, true)
 when /^Netscape/i
   conn = LDAP::SSLConn.new($HOST, $SSLPORT,
-			   false, File.expand_path("~/.netscape/cert7.db"))
+                           false, File.expand_path("~/.netscape/cert7.db"))
   conn.set_option(LDAP::LDAP_OPT_PROTOCOL_VERSION, 3)
 else
   raise(RuntimeError, "unknown vendor")

--- a/test/bind.rb
+++ b/test/bind.rb
@@ -20,7 +20,7 @@ conn.bind{
       info = nil
     end
     print("host = #{host}, proto = #{proto}\n",
-  	  "info.protocol_version = #{info.protocol_version}\n")
+          "info.protocol_version = #{info.protocol_version}\n")
   end
 }
 

--- a/test/compare.rb
+++ b/test/compare.rb
@@ -9,7 +9,7 @@ LDAP::Conn.new($HOST, $PORT).bind{|conn|
   conn.perror("bind")
   begin
     conn.compare("cn=Takaaki Tateishi, dc=localhost, dc=localdomain",
-		 "cn", "Takaaki Tateishi")
+                 "cn", "Takaaki Tateishi")
   rescue LDAP::ResultError
     exit(0)
   end

--- a/test/ext.rb
+++ b/test/ext.rb
@@ -11,9 +11,9 @@ conn.bind('cn=root, dc=localhost, dc=localdomain','secret'){
   begin
     (1..200).each{|i|
       entry = {
-	'objectclass' => ['top', 'person'],
-	'cn'          => ["User #{i}"],
-	'sn'          => ["user#{i}"],
+        'objectclass' => ['top', 'person'],
+        'cn'          => ["User #{i}"],
+        'sn'          => ["user#{i}"],
       }
       conn.add("cn=User #{i}, dc=localhost, dc=localdomain", entry)
     }
@@ -30,12 +30,12 @@ conn.bind('cn=root, dc=localhost, dc=localdomain','secret'){
   users = []
   begin
     conn.search_ext("dc=localhost, dc=localdomain",
-		    LDAP::LDAP_SCOPE_SUBTREE,
-		    "(&(objectclass=*)(cn=User*))",
-		    nil, false,    # attrs, attrsonly
-		    nil, nil,      # serverctrls, clientctrls
-		    0, 0,          # sec, usec
-		    100){|e|       # sizelimit
+                    LDAP::LDAP_SCOPE_SUBTREE,
+                    "(&(objectclass=*)(cn=User*))",
+                    nil, false,    # attrs, attrsonly
+                    nil, nil,      # serverctrls, clientctrls
+                    0, 0,          # sec, usec
+                    100){|e|       # sizelimit
       users.push(e.vals("sn"))
     }
   rescue LDAP::ResultError

--- a/test/modrdn.rb
+++ b/test/modrdn.rb
@@ -14,8 +14,8 @@ rescue LDAP::ResultError => e
   conn.bind('cn=root, dc=localhost, dc=localdomain','secret'){
     conn.perror("bind")
     conn.modrdn("cn=Takaaki Tateishi, dc=localhost, dc=localdomain",
-		"cn=Takaaki-Tateishi",
-		true)
+                "cn=Takaaki-Tateishi",
+                true)
     conn.perror("modrdn")
   }
   exit(0)

--- a/test/moz_cert.rb
+++ b/test/moz_cert.rb
@@ -6,8 +6,8 @@ require 'optparse'
 require 'pp'
 
 options = {
-  :host	  => 'localhost',
-  :port	  => '389',
+  :host   => 'localhost',
+  :port   => '389',
   :scope  => 'base',
   :filter => '(objectclass=*)',
   :key_pw => ''
@@ -15,44 +15,44 @@ options = {
 
 optparse = OptionParser.new do |opts|
   opts.on("-P", "--certpath [CERTFILE]", "cert8 path") do |cp|
-	options[:cp] = cp
+    options[:cp] = cp
   end
 
   opts.on("-N", "--certname [CERTNAME]", "certificate name") do |opt|
-	options[:cn] = opt
+    options[:cn] = opt
   end
 
   opts.on("-W", "--keypassword PASSWORD", "key password") do |opt|
-	options[:key_pw] = opt
+    options[:key_pw] = opt
   end
 
   opts.on("-h", "--host HOST", "server hostname") do |host|
-	options[:host] = host
+    options[:host] = host
   end
 
   opts.on("-p", "--port PORT", "server port") do |opt|
-	options[:port] = opt
+    options[:port] = opt
   end
 
   opts.on("-b", "--base [BASE]", "search base") do |opt|
-	options[:base] = opt
+    options[:base] = opt
   end
 
   opts.on("-s", "--scope SCOPE", "search scope") do |opt|
-	options[:scope] = opt
+    options[:scope] = opt
   end
 
   opts.on("-f", "--filter FILTER", "search filter") do |opt|
-	options[:filter] = opt
+    options[:filter] = opt
   end
 
   opts.on("-a", "--attributes ATTRS", "attrs to return") do |opt|
-	options[:attrs] = opt.split(/ *, */)
+    options[:attrs] = opt.split(/ *, */)
   end
 
   opts.on("--help") do |opt|
-	puts opts
-	exit 0
+    puts opts
+    exit 0
   end
 end
 
@@ -80,7 +80,7 @@ raise ArgumentError.new("cert file's missing") unless (File.exists? options[:cp]
 
 # Connect
 conn = LDAP::SSLAuthConn.new(options[:host], options[:port].to_i, true, 
-			    File.expand_path(options[:cp]), options[:cn], options[:key_pw])
+                File.expand_path(options[:cp]), options[:cn], options[:key_pw])
 conn.set_option(LDAP::LDAP_OPT_PROTOCOL_VERSION, 3)
 
 
@@ -93,7 +93,7 @@ begin
 
   results = {}
   conn.search(options[:base], options[:scope], options[:filter], options[:attrs], false, 10) do |entry|
-	results[entry.dn] = entry.to_hash
+    results[entry.dn] = entry.to_hash
   end
 
   pp results

--- a/test/search.rb
+++ b/test/search.rb
@@ -9,8 +9,8 @@ LDAP::Conn.new($HOST, $PORT).bind{|conn|
   conn.perror("bind")
   begin
     conn.search("dc=localhost, dc=localdomain",
-		LDAP::LDAP_SCOPE_SUBTREE,
-		"(objectclass=*)"){|e|
+                LDAP::LDAP_SCOPE_SUBTREE,
+                "(objectclass=*)"){|e|
       p e.vals("cn")
       p e.to_hash()
     }

--- a/test/search2.rb
+++ b/test/search2.rb
@@ -14,7 +14,7 @@ LDAP::Conn.new($HOST, $PORT).bind{|conn|
   conn.perror("bind")
   sub = nil
   conn.search("dc=localhost, dc=localdomain", LDAP::LDAP_SCOPE_SUBTREE,
-	      "(objectclass=*)", nil, false, 0, 0, "sn", sorter){|e|
+              "(objectclass=*)", nil, false, 0, 0, "sn", sorter){|e|
     dn = e.dn
     print("# #{LDAP.dn2ufn(dn)}\n")
     print("dn: #{dn}\n")
@@ -29,6 +29,6 @@ LDAP::Conn.new($HOST, $PORT).bind{|conn|
     sub.dn
   rescue LDAP::InvalidEntryError => e
     $stderr.print("#{e.to_s}.\n",
-		  "This exception is expected.\n")
+                  "This exception is expected.\n")
   end
 }

--- a/test/search3.rb
+++ b/test/search3.rb
@@ -13,7 +13,7 @@ conn.bind{
   # search2 returns an array of hash
   print("search2 without a block:\n")
   conn.search2("dc=localhost, dc=localdomain", LDAP::LDAP_SCOPE_SUBTREE,
-	       "(objectclass=*)", nil, false, 0, 0).each{|ent|
+               "(objectclass=*)", nil, false, 0, 0).each{|ent|
     ent.each{|attr,vals|
       print("#{attr}: #{vals.join(', ')}\n")
     }

--- a/test/setup.rb
+++ b/test/setup.rb
@@ -18,9 +18,9 @@ class TC_LDAPTest < Test::Unit::TestCase
           if line =~ /^host\s+(\S+)$/
             @@host = $1
             break
-	  elsif line =~ /^base\s+(\S+)$/
-	    @@base = $1
-	    break
+          elsif line =~ /^base\s+(\S+)$/
+            @@base = $1
+            break
           end
         end
       end

--- a/test/tc_conn.rb
+++ b/test/tc_conn.rb
@@ -120,5 +120,4 @@ class TC_ConnectionTest < TC_LDAPTest
     @@conn = nil
   end
 
-
 end

--- a/test/tc_ldif.rb
+++ b/test/tc_ldif.rb
@@ -86,7 +86,7 @@ class TC_LDIFTest < Test::Unit::TestCase
     ldif = File.open( 'data/ldif12.txt' ) { |f| f.readlines }
     entry = LDAP::LDIF.parse_entry( ldif )
     assert( entry.mods.keys.include?( LDAP::LDAP_MOD_REPLACE |
-				      LDAP::LDAP_MOD_BVALUES ) )
+                                      LDAP::LDAP_MOD_BVALUES ) )
   end
 
   def test_change_record_control
@@ -109,9 +109,9 @@ class TC_LDIFTest < Test::Unit::TestCase
 
   def test_mod_to_ldif
     mod = LDAP.mod( LDAP::LDAP_MOD_ADD | LDAP::LDAP_MOD_BVALUES,
-		    'mailRoutingAddress', ['a', 'b'] )
+                    'mailRoutingAddress', ['a', 'b'] )
     assert_instance_of( LDAP::LDIF::Mod,
-		        mod.to_ldif( 'uid=foo,dc=example,dc=com' ) )
+                        mod.to_ldif( 'uid=foo,dc=example,dc=com' ) )
     assert_equal( <<LDIF, mod.to_ldif( 'uid=foo,dc=example,dc=com' ) )
 dn: uid=foo,dc=example,dc=com
 changetype: add
@@ -120,7 +120,7 @@ mailRoutingAddress: b
 LDIF
 
     mod = LDAP.mod( LDAP::LDAP_MOD_REPLACE | LDAP::LDAP_MOD_BVALUES,
-		    'mailRoutingAddress', ['a', 'b'] )
+                    'mailRoutingAddress', ['a', 'b'] )
     assert_equal( <<LDIF, mod.to_ldif( 'uid=foo,dc=example,dc=com' ) )
 dn: uid=foo,dc=example,dc=com
 changetype: modify

--- a/test/tc_search.rb
+++ b/test/tc_search.rb
@@ -16,17 +16,17 @@ class TC_SearchTest < TC_LDAPTest
   def test_attrs
     assert_raise( TypeError ) do
       @@conn.search( @@naming_context, LDAP::LDAP_SCOPE_ONELEVEL,
-		     '(objectClass=*)', false )
+                     '(objectClass=*)', false )
     end
 
     @@conn.search( @@naming_context, LDAP::LDAP_SCOPE_ONELEVEL,
-		   '(objectClass=*)', [], true ) do |x|
+                   '(objectClass=*)', [], true ) do |x|
       assert_nil( x['objectClass'] )
       break
     end
 
     @@conn.search( @@naming_context, LDAP::LDAP_SCOPE_ONELEVEL,
-		   '(objectClass=*)', 'objectClass' ) do |x|
+                   '(objectClass=*)', 'objectClass' ) do |x|
       x = x.to_hash
       x.delete( 'dn' )
       assert( x.to_hash.keys == [ 'objectClass' ] )
@@ -39,14 +39,14 @@ class TC_SearchTest < TC_LDAPTest
   def test_sort_attr
     ou = []
     @@conn.search( @@naming_context, LDAP::LDAP_SCOPE_ONELEVEL,
-		   '(ou=*)' ) do |x|
+                   '(ou=*)' ) do |x|
       ou << x['ou']
     end
     ou.flatten!
 
     sorted_ou = []
     @@conn.search( @@naming_context, LDAP::LDAP_SCOPE_ONELEVEL,
-		   '(ou=*)', nil, nil, 0, 0, 'ou' ) do |x|
+                   '(ou=*)', nil, nil, 0, 0, 'ou' ) do |x|
       sorted_ou << x['ou']
     end
     sorted_ou.flatten!
@@ -60,7 +60,7 @@ class TC_SearchTest < TC_LDAPTest
   def test_sort_proc
     ct = []
     @@conn.search( @@naming_context, LDAP::LDAP_SCOPE_ONELEVEL,
-		   '(objectClass=*)', [ 'createTimestamp' ] ) do |x|
+                   '(objectClass=*)', [ 'createTimestamp' ] ) do |x|
       ct << x['createTimestamp']
     end
     ct.flatten!
@@ -68,8 +68,8 @@ class TC_SearchTest < TC_LDAPTest
     sorted_ct = []
     s_proc = proc { |a,b| b <=> a }
     @@conn.search( @@naming_context, LDAP::LDAP_SCOPE_ONELEVEL,
-		   '(objectClass=*)', [ 'createTimestamp' ], nil, 0, 0,
-		   'createTimestamp', s_proc ) do |x|
+                   '(objectClass=*)', [ 'createTimestamp' ], nil, 0, 0,
+                   'createTimestamp', s_proc ) do |x|
       sorted_ct << x['createTimestamp']
     end
     sorted_ct.flatten!
@@ -88,20 +88,20 @@ class TC_SearchTest < TC_LDAPTest
     loop do
       ber_string = LDAP::Control.encode( page_size, cookie )
       ctrl = LDAP::Control.new( LDAP::LDAP_CONTROL_PAGEDRESULTS,
-			        ber_string,
-				true )
+                                ber_string,
+                                true )
       @@conn.set_option( LDAP::LDAP_OPT_SERVER_CONTROLS, [ ctrl ] )
 
       this_page = nil
       assert_nothing_raised do
-	begin
+        begin
           this_page = @@conn.search2( @@naming_context,
-				      LDAP::LDAP_SCOPE_ONELEVEL,
-				      '(objectclass=*)' )
-	rescue LDAP::ResultError
-	  @@conn = nil
-	  raise
-	end
+                                      LDAP::LDAP_SCOPE_ONELEVEL,
+                                      '(objectclass=*)' )
+        rescue LDAP::ResultError
+          @@conn = nil
+          raise
+        end
       end
       total += this_page.size
       assert_equal( page_size, this_page.size )
@@ -126,7 +126,7 @@ class TC_SearchTest < TC_LDAPTest
     setup
 
     unpaged = @@conn.search2( @@naming_context, LDAP::LDAP_SCOPE_ONELEVEL,
-			      '(objectclass=*)' )
+                              '(objectclass=*)' )
 
     # Does the total number of results match the equivalent unpaged search?
     # This has a race condition, but we assume the number of top-level OUs is

--- a/test/test.sh
+++ b/test/test.sh
@@ -21,12 +21,12 @@ SCRIPTS="$TEST/bind.rb \
          $TEST/search.rb \
          $TEST/search2.rb \
          $TEST/search3.rb \
-	 $TEST/search4.rb \
-	 $TEST/search5.rb \
+         $TEST/search4.rb \
+         $TEST/search5.rb \
          $TEST/modrdn.rb \
          $TEST/search2.rb \
          $TEST/delete.rb \
-	 $TEST/search2.rb \
+         $TEST/search2.rb \
          $TEST/compare.rb \
          $TEST/ext.rb \
          $TEST/misc1.rb \
@@ -95,7 +95,7 @@ case "$2" in
 'newcert')
   openssl req -new -x509 -out ./test-db/server.pem \
           -nodes -keyout ./test-db/server.pem \
-	  -config $TEST/openssl/openssl.cnf
+          -config $TEST/openssl/openssl.cnf
   exit 0
   ;;
 *)


### PR DESCRIPTION
Hi.

Tab has mixed in some places of the test code.
Since impede code reading, it was replaced by a space.