### PR TITLE
Support LDAP_OPT_X_TLS_NEWCTX

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -502,6 +502,9 @@ rb_ldap_conn_set_option (VALUE self, VALUE opt, VALUE data)
 #ifdef LDAP_OPT_X_TLS_REQUIRE_CERT
     case LDAP_OPT_X_TLS_REQUIRE_CERT:
 #endif
+#ifdef LDAP_OPT_X_TLS_NEWCTX
+    case LDAP_OPT_X_TLS_NEWCTX:
+#endif
 #endif
       idata = NUM2INT (data);
       optdata = &idata;

--- a/ldap.c
+++ b/ldap.c
@@ -496,6 +496,9 @@ Init_ldap ()
 #ifdef LDAP_OPT_X_TLS_RANDOM_FILE
   rb_ldap_define_opt (LDAP_OPT_X_TLS_RANDOM_FILE);
 #endif
+#ifdef LDAP_OPT_X_TLS_NEWCTX
+  rb_ldap_define_opt (LDAP_OPT_X_TLS_NEWCTX);
+#endif
 #ifdef LDAP_OPT_X_TLS_NEVER
   rb_ldap_define_opt (LDAP_OPT_X_TLS_NEVER);
 #endif


### PR DESCRIPTION
It's needed for setting StartTLS related options in GnuTLS backend:

    connection = LDAP::Conn.new(host, port)
    connection.set_option(LDAP::LDAP_OPT_X_TLS_REQUIRE_CERT,
                          LDAP::LDAP_OPT_X_TLS_NEVER)
    connection.set_option(LDAP::LDAP_OPT_X_TLS_NEXCTX, 1) # This is needed
    connection.start_tls